### PR TITLE
freeze comments

### DIFF
--- a/src/AppBundle/Entity/Decklist.php
+++ b/src/AppBundle/Entity/Decklist.php
@@ -63,6 +63,10 @@ class Decklist extends \AppBundle\Model\ExportableDeck implements \JsonSerializa
      */
     private $nbComments;
     /**
+     * @var bool
+     */
+    private $freezeComments;
+    /**
      * @var integer
      */
     private $version;
@@ -375,6 +379,28 @@ class Decklist extends \AppBundle\Model\ExportableDeck implements \JsonSerializa
      */
     public function getNbComments() {
         return $this->nbComments;
+    }
+
+    /**
+     * Set freezeComments
+     *
+     * @param integer $freezeComments
+     *
+     * @return Decklist
+     */
+    public function setFreezeComments($freezeComments) {
+        $this->freezeComments = $freezeComments;
+
+        return $this;
+    }
+
+    /**
+     * Get freezeComments
+     *
+     * @return integer
+     */
+    public function getFreezeComments() {
+        return $this->freezeComments;
     }
 
     /**

--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -19,6 +19,7 @@ class ExportableDeck {
             'slots' => $slots->getContent(),
             'sideslots' => $sideslots->getContent(),
             'version' => $this->getVersion(),
+            'freeze_comments' => $this->getFreezeComments(),
         ];
 
         return $array;

--- a/src/AppBundle/Resources/config/doctrine/Decklist.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Decklist.orm.yml
@@ -154,6 +154,9 @@ AppBundle\Entity\Decklist:
         nbComments:
             type: integer
             column: nb_comments
+        freezeComments:
+            type: boolean
+            column: freeze_comments
         version:
             type: string
             length: 8

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -9,6 +9,7 @@
     var unsaved;
     var user_id;
     var is_published;
+    var freeze_comments;
 
     var header_tpl = _.template('<h5><span class="icon icon-<%= code %>"></span> <%= name %> (<%= quantity %>)</h5>');
     var card_line_tpl = _.template('<span class="icon icon-<%= card.type_code %> fg-<%= card.sphere_code %>"></span> <a href="<%= card.url %>" class="card card-tip fg-<%= card.sphere_code %>" data-toggle="modal" data-remote="false" data-target="#cardModal" data-code="<%= card.code %>"><%= card.name %></a>');
@@ -68,6 +69,7 @@
         unsaved = data.unsaved;
         user_id = data.user_id;
         is_published = data.is_published;
+        freeze_comments = data.freeze_comments;
 
         if (app.data.isLoaded) {
             deck.set_slots(data.slots, data.sideslots);
@@ -131,6 +133,14 @@
      */
     deck.get_description_md = function() {
         return description_md;
+    };
+
+    /**
+     * @memberOf deck
+     * @returns boolean
+     */
+    deck.get_freeze_comments = function() {
+        return freeze_comments;
     };
 
     /**

--- a/src/AppBundle/Resources/public/js/ui.decklist.js
+++ b/src/AppBundle/Resources/public/js/ui.decklist.js
@@ -122,47 +122,51 @@
     };
 
     ui.setup_comment_form = function() {
-        var form = $(
-            '<form method="POST" action="' + Routing.generate('decklist_comment') + '"><input type="hidden" name="id" value="' + app.deck.get_id() + '"><div class="form-group">' +
-            '<textarea id="comment-form-text" class="form-control" rows="4" name="comment" placeholder="Enter your comment in Markdown format. Type # to enter a card name. Type $ to enter a symbol. Type @ to enter a user name."></textarea>' +
-            '</div><div class="well text-muted" id="comment-form-preview"></div><button type="submit" class="btn btn-success">Submit comment</button></form>'
-        ).insertAfter('#comment-form');
+        if (app.deck.get_freeze_comments()) {
+            $('<p>Commenting on this decklist is temporarily disabled.</p>').insertAfter('#comment-form');
+        } else {
+            var form = $(
+                '<form method="POST" action="' + Routing.generate('decklist_comment') + '"><input type="hidden" name="id" value="' + app.deck.get_id() + '"><div class="form-group">' +
+                '<textarea id="comment-form-text" class="form-control" rows="4" name="comment" placeholder="Enter a comment in Markdown format. Type # to enter a card name. Type $ to enter a symbol. Type @ to enter a user name."></textarea>' +
+                '</div><div class="well text-muted" id="comment-form-preview"></div><button type="submit" class="btn btn-success">Submit comment</button></form>'
+            ).insertAfter('#comment-form');
+        
+            var already_submitted = false;
+            form.on('submit', function(event) {
+                event.preventDefault();
 
-        var already_submitted = false;
-        form.on('submit', function(event) {
-            event.preventDefault();
+                var data = $(this).serialize();
 
-            var data = $(this).serialize();
-
-            if (already_submitted) {
-                return;
-            }
-
-            already_submitted = true;
-
-            $.ajax(Routing.generate('decklist_comment'), {
-                data: data,
-                type: 'POST',
-                success: function(data, textStatus, jqXHR) {
-                    form.replaceWith('<div class="alert alert-success" role="alert">Your comment has been posted. It will appear on the site in a few minutes.</div>');
-                },
-                error: function(jqXHR, textStatus, errorThrown) {
-                    console.log('[' + moment().format('YYYY-MM-DD HH:mm:ss') + '] Error on ' + this.url, textStatus, errorThrown);
-                    form.replaceWith('<div class="alert alert-danger" role="alert">An error occured while posting your comment (' + jqXHR.statusText + '). Reload the page and try again.</div>');
+                if (already_submitted) {
+                    return;
                 }
+
+                already_submitted = true;
+
+                $.ajax(Routing.generate('decklist_comment'), {
+                    data: data,
+                    type: 'POST',
+                    success: function(data, textStatus, jqXHR) {
+                        form.replaceWith('<div class="alert alert-success" role="alert">Your comment has been posted. It will appear on the site in a few minutes.</div>');
+                    },
+                    error: function(jqXHR, textStatus, errorThrown) {
+                        console.log('[' + moment().format('YYYY-MM-DD HH:mm:ss') + '] Error on ' + this.url, textStatus, errorThrown);
+                        form.replaceWith('<div class="alert alert-danger" role="alert">An error occured while posting your comment (' + jqXHR.statusText + '). Reload the page and try again.</div>');
+                    }
+                });
             });
-        });
 
-        $('.social .social-icon-comment').on('click', function() {
-            $('#comment-form-text').trigger('focus');
-        });
+            $('.social .social-icon-comment').on('click', function() {
+                $('#comment-form-text').trigger('focus');
+            });
 
-        app.markdown.setup('#comment-form-text', '#comment-form-preview');
-        app.textcomplete.setup('#comment-form-text', {
-            cards: true,
-            icons: true,
-            users: Commenters
-        });
+            app.markdown.setup('#comment-form-text', '#comment-form-preview');
+            app.textcomplete.setup('#comment-form-text', {
+                cards: true,
+                icons: true,
+                users: Commenters
+            });
+        }
     };
 
     ui.setup_social_icons = function() {


### PR DESCRIPTION
Allow commenting on a decklist to be disabled. Currently only settable via SQL, so this is a moderator-only feature. Would like to add the ability for a user to disable commenting on their own decklist if they wish.